### PR TITLE
Upgrade to Beam 2.20.0 + fix vulnerabilities

### DIFF
--- a/beam-sdks-java-io-solace/pom.xml
+++ b/beam-sdks-java-io-solace/pom.xml
@@ -15,12 +15,14 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.solace.connector.beam</groupId>
 		<artifactId>solace-apache-beam-parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>beam-sdks-java-io-solace</artifactId>

--- a/beam-sdks-java-io-solace/pom.xml
+++ b/beam-sdks-java-io-solace/pom.xml
@@ -41,6 +41,44 @@
 			<artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
 		</dependency>
 
+		<!--
+			APACHE BEAM VULNERABILITIES FIXES [MUST REDO FOR EACH APACHE BEAM UPDATE]
+			- - - - - - - - START - - - - - - - -
+		-->
+		<!-- Fixes avro:1.8.2 -->
+		<dependency>
+			<groupId>org.apache.avro</groupId>
+			<artifactId>avro</artifactId>
+			<version>1.9.2</version>
+		</dependency>
+
+		<!-- Fixes netty-codec:4.1.30.Final -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-codec</artifactId>
+			<version>4.1.49.Final</version>
+		</dependency>
+
+		<!-- Fixes netty-codec-http:4.1.30.Final -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-codec-http</artifactId>
+			<version>4.1.49.Final</version>
+		</dependency>
+
+		<!-- Fixes okhttp:2.5.0 -->
+		<dependency>
+			<groupId>com.squareup.okhttp</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>2.7.5</version>
+		</dependency>
+
+		<!--
+			- - - - - - - - END - - - - - - - -
+			APACHE BEAM VULNERABILITIES FIXES [MUST REDO FOR EACH APACHE BEAM UPDATE]
+		-->
+
+
 		<dependency>
 			<groupId>com.solacesystems</groupId>
 			<artifactId>sol-jcsmp</artifactId>
@@ -96,18 +134,6 @@
 		<dependency>
 			<groupId>org.apache.beam</groupId>
 			<artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<!--
-			Workaround for dependency conflict when using beam-runners-google-cloud-dataflow-java.
-			Remove this when Apache Beam 2.20.0 comes out.
-			https://issues.apache.org/jira/browse/BEAM-9304
-		-->
-		<dependency>
-			<groupId>io.opencensus</groupId>
-			<artifactId>opencensus-api</artifactId>
-			<version>0.18.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/beam-sdks-java-io-solace/pom.xml
+++ b/beam-sdks-java-io-solace/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.solace.connector.beam</groupId>
 		<artifactId>solace-apache-beam-parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.0.0</version>
 	</parent>
 
 	<artifactId>beam-sdks-java-io-solace</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,14 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.solace.connector.beam</groupId>
   <artifactId>solace-apache-beam-parent</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Beam Solace PubSub+ I/O Parent</name>
@@ -60,7 +62,7 @@
     <url>https://github.com/${repoName}/solace-apache-beam.git</url>
     <connection>scm:git:git://github.com/${repoName}/solace-apache-beam.git</connection>
     <developerConnection>scm:git:git@github.com:${repoName}/solace-apache-beam.git</developerConnection>
-    <tag>1.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,8 @@
   <properties>
     <repoName>SolaceProducts</repoName>
 
-    <!--
-    Upgrade to 2.19.0 or higher once this issue is fixed:
-    https://issues.apache.org/jira/browse/BEAM-9471
-    -->
-    <beam.version>2.18.0</beam.version>
-
-    <jcsmp.version>10.7.0</jcsmp.version>
+    <beam.version>2.20.0</beam.version>
+    <jcsmp.version>10.8.0</jcsmp.version>
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.solace.connector.beam</groupId>
   <artifactId>solace-apache-beam-parent</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
 
   <name>Apache Beam Solace PubSub+ I/O Parent</name>
@@ -60,7 +60,7 @@
     <url>https://github.com/${repoName}/solace-apache-beam.git</url>
     <connection>scm:git:git://github.com/${repoName}/solace-apache-beam.git</connection>
     <developerConnection>scm:git:git@github.com:${repoName}/solace-apache-beam.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>1.0.0</tag>
   </scm>
 
   <modules>

--- a/solace-apache-beam-samples/pom.xml
+++ b/solace-apache-beam-samples/pom.xml
@@ -15,12 +15,14 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.solace.connector.beam</groupId>
 		<artifactId>solace-apache-beam-parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>solace-apache-beam-samples</artifactId>
@@ -31,7 +33,7 @@
 
 	<properties>
 		<beam.version>2.20.0</beam.version>
-		<solace-beam.version>1.0.0</solace-beam.version>
+		<solace-beam.version>1.0.0-SNAPSHOT</solace-beam.version>
 
 		<bigquery.version>v2-rev374-1.23.0</bigquery.version>
 		<google-clients.version>1.30.2</google-clients.version>
@@ -258,7 +260,7 @@
 								</filter>
 							</filters>
 							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 							</transformers>
 						</configuration>
 					</execution>

--- a/solace-apache-beam-samples/pom.xml
+++ b/solace-apache-beam-samples/pom.xml
@@ -30,7 +30,7 @@
 	<description>Samples for the Apache Beam I/O Component for Solace PubSub+</description>
 
 	<properties>
-		<beam.version>2.18.0</beam.version>
+		<beam.version>2.20.0</beam.version>
 		<solace-beam.version>1.1.0-SNAPSHOT</solace-beam.version>
 
 		<bigquery.version>v2-rev374-1.23.0</bigquery.version>

--- a/solace-apache-beam-samples/pom.xml
+++ b/solace-apache-beam-samples/pom.xml
@@ -35,15 +35,9 @@
 		<beam.version>2.20.0</beam.version>
 		<solace-beam.version>1.0.0-SNAPSHOT</solace-beam.version>
 
-		<bigquery.version>v2-rev374-1.23.0</bigquery.version>
-		<google-clients.version>1.30.2</google-clients.version>
-		<guava.version>20.0</guava.version>
-		<hamcrest.version>1.3</hamcrest.version>
-		<joda.version>2.4</joda.version>
 		<maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
 		<maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
 		<maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
-		<pubsub.version>v1-rev382-1.23.0</pubsub.version>
 		<slf4j.version>1.7.25</slf4j.version>
 	</properties>
 
@@ -71,93 +65,11 @@
 			<artifactId>beam-sdks-java-io-solace</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>com.google.api-client</groupId>
-			<artifactId>google-api-client</artifactId>
-			<version>${google-clients.version}</version>
-			<exclusions>
-				<!-- Exclude an old version of guava that is being pulled
-					 in by a transitive dependency of google-api-client -->
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava-jdk5</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.apis</groupId>
-			<artifactId>google-api-services-bigquery</artifactId>
-			<version>${bigquery.version}</version>
-			<exclusions>
-				<!-- Exclude an old version of guava that is being pulled
-					 in by a transitive dependency of google-api-client -->
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava-jdk5</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.http-client</groupId>
-			<artifactId>google-http-client</artifactId>
-			<version>${google-clients.version}</version>
-			<exclusions>
-				<!-- Exclude an old version of guava that is being pulled
-					 in by a transitive dependency of google-api-client -->
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava-jdk5</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.apis</groupId>
-			<artifactId>google-api-services-pubsub</artifactId>
-			<version>${pubsub.version}</version>
-			<exclusions>
-				<!-- Exclude an old version of guava that is being pulled
-					 in by a transitive dependency of google-api-client -->
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava-jdk5</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>${joda.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
-
 		<!-- Add slf4j API frontend binding with JUL backend -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
-		</dependency>
-
-		<!-- Hamcrest and JUnit are required dependencies of PAssert,
-			 which is used in the main code of DebuggingWordCount example. -->
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>${hamcrest.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>${hamcrest.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/solace-apache-beam-samples/pom.xml
+++ b/solace-apache-beam-samples/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.solace.connector.beam</groupId>
 		<artifactId>solace-apache-beam-parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.0.0</version>
 	</parent>
 
 	<artifactId>solace-apache-beam-samples</artifactId>
@@ -31,7 +31,7 @@
 
 	<properties>
 		<beam.version>2.20.0</beam.version>
-		<solace-beam.version>1.1.0-SNAPSHOT</solace-beam.version>
+		<solace-beam.version>1.0.0</solace-beam.version>
 
 		<bigquery.version>v2-rev374-1.23.0</bigquery.version>
 		<google-clients.version>1.30.2</google-clients.version>


### PR DESCRIPTION
# Dependency Updates
| Dependency | Old Version | New Version | Notes |
| - | - | - | - |
| sol-jcsmp | 10.7.0 | 10.8.0 | not vulnerability-related, but might as well update it |
| beam-sdks-java-bom | 2.18.0 | 2.20.0 | Fixes a bunch of vulnerabilities |
| avro | 1.8.2 | 1.9.2 | Fixes nested vulnerabilities |
| netty-codec | 4.1.30.Final | 4.1.49.Final | Fixes vulnerability from old version |
| netty-codec-http | 4.1.30.Final | 4.1.49.Final | Fixes vulnerability from old version |
| okhttp | 2.5.0 | 2.7.5 | Fixes vulnerability from old version |
| opencensus-api | 0.18.0 | | Don't need anymore. [BEAM-9304](https://issues.apache.org/jira/browse/BEAM-9304) is fixed now. |