### PR TITLE
Fix Apache Beam SDK 2.25+ SDF Read issues

### DIFF
--- a/beam-sdks-java-io-solace/src/main/java/com/solace/connector/beam/SolaceCheckpointMark.java
+++ b/beam-sdks-java-io-solace/src/main/java/com/solace/connector/beam/SolaceCheckpointMark.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import com.solacesystems.jcsmp.FlowReceiver;
+
 /**
  * Checkpoint for an unbounded Solace source. Consists of the Solace messages waiting to be
  * acknowledged and oldest pending message timestamp.
@@ -21,31 +23,34 @@ class SolaceCheckpointMark implements UnboundedSource.CheckpointMark, Serializab
 	private static final long serialVersionUID = 42L;
 	private static final Logger LOG = LoggerFactory.getLogger(SolaceCheckpointMark.class);
 
-	private final UUID id;
+	// this is made transient because the CheckpointMark is being used as a cache marker
+	// keeping the ID during serialization will cause the reader not to be reused
+	private transient final UUID id;
 	@Nullable
 	private transient UnboundedSolaceReader<?> reader;
+	private transient FlowReceiver flowReceiver;
 	private String clientName;
 	private transient BlockingQueue<UnboundedSolaceReader.Message> ackQueue;
 
 	public SolaceCheckpointMark(UnboundedSolaceReader<?> reader,
+								FlowReceiver flowReceiver,
 								String clientName,
 								BlockingQueue<UnboundedSolaceReader.Message> ackQueue) {
 		this.id = UUID.randomUUID();
 		this.reader = reader;
+		this.flowReceiver = flowReceiver;
 		this.clientName = clientName;
 		this.ackQueue = ackQueue;
-		LOG.debug(String.format("Created %s %s", this.getClass().getSimpleName(), this.id));
+		LOG.debug("Created {} for {}", this.id, this.clientName);
 	}
-
 
 	@Override
 	public void finalizeCheckpoint() throws IOException {
 		if (reader != null) {
 			if (!reader.active.get()) {
+				LOG.warn("Failed to finalize {} with {} items", this.id, this.ackQueue.size());
 				return;
 			}
-			LOG.debug(String.format("Started to finalize %s %s", this.getClass().getSimpleName(), this.id));
-
 			int ackListSize = ackQueue.size();
 			try {
 				while (ackQueue.size() > 0) {
@@ -59,6 +64,7 @@ class SolaceCheckpointMark implements UnboundedSource.CheckpointMark, Serializab
 					}
 				}
 				reader.readerStats.incrCheckpointCompleteMessages((long) ackListSize);
+				flowReceiver.close();
 			} catch (Exception e) {
 				LOG.error(String.format("Got exception while acknowledging %s %s: %s",
 						this.getClass().getSimpleName(), this.id, e.toString()), e);
@@ -71,8 +77,9 @@ class SolaceCheckpointMark implements UnboundedSource.CheckpointMark, Serializab
 	public boolean equals(Object other) {
 		if (other instanceof SolaceCheckpointMark) {
 			SolaceCheckpointMark that = (SolaceCheckpointMark) other;
+			// use only flowReceiver here because of transitive property (same flowReceiver implies same reader)
 			return this.clientName.equals(that.clientName)
-					&& (this.reader == that.reader);
+					&& (this.flowReceiver == that.flowReceiver);
 		} else {
 			return false;
 		}
@@ -81,7 +88,7 @@ class SolaceCheckpointMark implements UnboundedSource.CheckpointMark, Serializab
 	@Override
 	public int hashCode() {
 		// Effective Java Item 11
-		return clientName.hashCode() * 31 + System.identityHashCode(reader);
+		return clientName.hashCode() * 31 + System.identityHashCode(flowReceiver);
 	}
 
 }

--- a/beam-sdks-java-io-solace/src/main/java/com/solace/connector/beam/UnboundedSolaceReader.java
+++ b/beam-sdks-java-io-solace/src/main/java/com/solace/connector/beam/UnboundedSolaceReader.java
@@ -116,6 +116,7 @@ class UnboundedSolaceReader<T> extends UnboundedSource.UnboundedReader<T> {
 				throw new IOException(ex);
 			}
 		}
+		return true;
 	}
 
 	@Override
@@ -319,11 +320,11 @@ class UnboundedSolaceReader<T> extends UnboundedSource.UnboundedReader<T> {
 			// downgraded from error because the worker still returns a valid value -- unknown amount of data left
 			// mainly affects the scaling responsiveness of the pipeline in Dataflow and requires a large number of messages remaining consistently before scaling would be triggered
 			// it instead distracts from other errors because once this triggers (e.g. due to having more clients that expected), it will keep popping up
-			LOG.warning(String.format("Encountered a JCSMPException querying queue depth: %s", e.getMessage()), e);
+			LOG.warn(String.format("Encountered a JCSMPException querying queue depth: %s", e.getMessage()), e);
 			return UnboundedSource.UnboundedReader.BACKLOG_UNKNOWN;
 		} catch (Exception e) {
 			// see above
-			LOG.warning(String.format("Encountered a Parser Exception querying queue depth: %s", e.toString()), e);
+			LOG.warn(String.format("Encountered a Parser Exception querying queue depth: %s", e.toString()), e);
 			return UnboundedSource.UnboundedReader.BACKLOG_UNKNOWN;
 		} finally {
 			try {
@@ -343,7 +344,7 @@ class UnboundedSolaceReader<T> extends UnboundedSource.UnboundedReader<T> {
 		long backlogBytes = queryQueueBytes(source.getQueueName(),
 				source.getSpec().jcsmpProperties().getStringProperty(JCSMPProperties.VPN_NAME));
 		if (backlogBytes == UnboundedSource.UnboundedReader.BACKLOG_UNKNOWN) {
-			LOG.warning("getSplitBacklogBytes() unable to read bytes from: {}", source.getQueueName());
+			LOG.warn("getSplitBacklogBytes() unable to read bytes from: {}", source.getQueueName());
 			return UnboundedSource.UnboundedReader.BACKLOG_UNKNOWN;
 		}
 		readerStats.setCurrentBacklog(backlogBytes);


### PR DESCRIPTION
This replaces #30 with a more robust solution that involves handing off `flowReceiver` to the `CheckpointMark` and creating a new one in the event of reuse. This works because a started `flowReceiver` indicates and allows for buffered messages which are neither sendable to other consumers nor processed by Apache Beam, and handing it off to the `CheckpointMark` allows the `flowReceiver` to be closed and finalized together with the checkpoint itself.

Another source of errors is getSplitBacklogBytes() whose reader is created but not started after Beam 2.25+, resulting in a load of NullPointerException errors.