### PR TITLE
Don't ship an SLF4J impl

### DIFF
--- a/beam-sdks-java-io-solace/pom.xml
+++ b/beam-sdks-java-io-solace/pom.xml
@@ -93,8 +93,15 @@
 
 		<dependency>
 			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.25</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.25</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Instead of including slf4j-simple, depend on slf4j-api and then include
slfj4-simple as a test dependency (libraries shouldn't depend on a
particular SLF4J implementation).