### PR TITLE
Remove messages from checkpoint ack queue if flow rebound

### DIFF
--- a/beam-sdks-java-io-solace/src/main/java/com/solace/connector/beam/SolaceReaderStats.java
+++ b/beam-sdks-java-io-solace/src/main/java/com/solace/connector/beam/SolaceReaderStats.java
@@ -1,12 +1,11 @@
 package com.solace.connector.beam;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
-
-import org.joda.time.Instant;
 
 
 /**
@@ -25,6 +24,8 @@ class SolaceReaderStats implements Serializable {
 	private Long currentBacklogBytes;
 	private Long checkpointReadyMessages;
 	private Long checkpointCompleteMessages;
+	private Long pollFlowRebind;
+	private Long messagesRemovedFromCheckpointQueue;
 	private Long monitorChecks;
 	private Long monitorFlowClose;
 
@@ -39,6 +40,8 @@ class SolaceReaderStats implements Serializable {
 		currentBacklogBytes = 0L;
 		checkpointReadyMessages = 0L;
 		checkpointCompleteMessages = 0L;
+		pollFlowRebind = 0L;
+		messagesRemovedFromCheckpointQueue = 0L;
 		monitorChecks = 0L;
 		monitorFlowClose = 0L;
 	}
@@ -49,6 +52,14 @@ class SolaceReaderStats implements Serializable {
 
 	public void incrementMessageReceived() {
 		msgRecieved++;
+	}
+
+	public void incrementPollFlowRebind() {
+		pollFlowRebind++;
+	}
+
+	public void incrementMessagesRemovedFromCheckpointQueue(long count) {
+		messagesRemovedFromCheckpointQueue += count;
 	}
 
 	public void incrementMonitorChecks() {
@@ -87,6 +98,42 @@ class SolaceReaderStats implements Serializable {
 		checkpointCompleteMessages = checkpointCompleteMessages + count;
 	}
 
+	public Long getEmptyPoll() {
+		return emptyPoll;
+	}
+
+	public Long getMsgRecieved() {
+		return msgRecieved;
+	}
+
+	public Long getCurrentBacklogBytes() {
+		return currentBacklogBytes;
+	}
+
+	public Long getCheckpointReadyMessages() {
+		return checkpointReadyMessages;
+	}
+
+	public Long getCheckpointCompleteMessages() {
+		return checkpointCompleteMessages;
+	}
+
+	public Long getPollFlowRebind() {
+		return pollFlowRebind;
+	}
+
+	public Long getMessagesRemovedFromCheckpointQueue() {
+		return messagesRemovedFromCheckpointQueue;
+	}
+
+	public Long getMonitorChecks() {
+		return monitorChecks;
+	}
+
+	public Long getMonitorFlowClose() {
+		return monitorFlowClose;
+	}
+
 	public String dumpStatsAndClear(Boolean verbose) {
 		String results = this.dumpStats(verbose);
 		this.zeroStats();
@@ -95,13 +142,15 @@ class SolaceReaderStats implements Serializable {
 
 	public String dumpStats(Boolean verbose) {
 		String results = "{";
-		results += "\"queueBacklog\":" + Long.toString(currentBacklogBytes) + ",";
-		results += "\"emptyPolls\":" + Long.toString(emptyPoll) + ",";
-		results += "\"messagesReceived\":" + Long.toString(msgRecieved) + ",";
-		results += "\"messagesCheckpointReady\":" + Long.toString(checkpointReadyMessages) + ",";
-		results += "\"messagesCheckpointComplete\":" + Long.toString(checkpointCompleteMessages) + ",";
-		results += "\"monitorChecks\":" + Long.toString(monitorChecks) + ",";
-		results += "\"monitorFlowClose\":" + Long.toString(monitorFlowClose) + "}";
+		results += "\"queueBacklog\":" + currentBacklogBytes + ",";
+		results += "\"emptyPolls\":" + emptyPoll + ",";
+		results += "\"messagesReceived\":" + msgRecieved + ",";
+		results += "\"messagesCheckpointReady\":" + checkpointReadyMessages + ",";
+		results += "\"messagesCheckpointComplete\":" + checkpointCompleteMessages + ",";
+		results += "\"pollFlowRebind\":" + pollFlowRebind + ",";
+		results += "\"messagesRemovedFromCheckpointQueue\":" + messagesRemovedFromCheckpointQueue + ",";
+		results += "\"monitorChecks\":" + monitorChecks + ",";
+		results += "\"monitorFlowClose\":" + monitorFlowClose + "}";
 		return results;
 	}
 

--- a/beam-sdks-java-io-solace/src/test/java/com/solace/connector/beam/SolaceReaderStatsTest.java
+++ b/beam-sdks-java-io-solace/src/test/java/com/solace/connector/beam/SolaceReaderStatsTest.java
@@ -21,6 +21,8 @@ public class SolaceReaderStatsTest {
 	private Long currentBacklogBytes;
 	private Long checkpointReadyMessages;
 	private Long checkpointCompleteMessages;
+	private Long pollFlowRebind;
+	private Long messagesRemovedFromCheckpointQueue;
 	private Long monitorChecks;
 	private Long monitorFlowClose;
 
@@ -36,6 +38,8 @@ public class SolaceReaderStatsTest {
 		currentBacklogBytes = Math.abs(random.nextLong());
 		checkpointReadyMessages = Math.abs(random.nextLong());
 		checkpointCompleteMessages = Math.abs(random.nextLong());
+		pollFlowRebind = Math.abs(random.nextLong()) % 100;
+		messagesRemovedFromCheckpointQueue = Math.abs(random.nextLong());
 		monitorChecks = Math.abs(random.nextLong())% 100;
 		monitorFlowClose = Math.abs(random.nextLong())% 100;
 
@@ -48,6 +52,8 @@ public class SolaceReaderStatsTest {
 		solaceReaderStats.setCurrentBacklog(currentBacklogBytes);
 		solaceReaderStats.incrCheckpointReadyMessages(checkpointReadyMessages);
 		solaceReaderStats.incrCheckpointCompleteMessages(checkpointCompleteMessages);
+		for (int i = 0; i < pollFlowRebind; i++) solaceReaderStats.incrementPollFlowRebind();
+		solaceReaderStats.incrementMessagesRemovedFromCheckpointQueue(messagesRemovedFromCheckpointQueue);
 		for (int i = 0; i < monitorChecks; i++) solaceReaderStats.incrementMonitorChecks();
 		for (int i = 0; i < monitorFlowClose; i++) solaceReaderStats.incrementMonitorFlowClose();
 	}
@@ -81,6 +87,8 @@ public class SolaceReaderStatsTest {
 		assertThat(dump, containsString(String.format("\"messagesReceived\":%s", msgRecieved)));
 		assertThat(dump, containsString(String.format("\"messagesCheckpointReady\":%s", checkpointReadyMessages)));
 		assertThat(dump, containsString(String.format("\"messagesCheckpointComplete\":%s", checkpointCompleteMessages)));
+		assertThat(dump, containsString(String.format("\"pollFlowRebind\":%s", pollFlowRebind)));
+		assertThat(dump, containsString(String.format("\"messagesRemovedFromCheckpointQueue\":%s", messagesRemovedFromCheckpointQueue)));
 		assertThat(dump, containsString(String.format("\"monitorChecks\":%s", monitorChecks)));
 		assertThat(dump, containsString(String.format("\"monitorFlowClose\":%s", monitorFlowClose)));
 		assertEquals(lastReportTime, solaceReaderStats.getLastReportTime());
@@ -93,6 +101,8 @@ public class SolaceReaderStatsTest {
 		expected += "\"messagesReceived\":0,";
 		expected += "\"messagesCheckpointReady\":0,";
 		expected += "\"messagesCheckpointComplete\":0,";
+		expected += "\"pollFlowRebind\":0,";
+		expected += "\"messagesRemovedFromCheckpointQueue\":0,";
 		expected += "\"monitorChecks\":0,";
 		expected += "\"monitorFlowClose\":0}";
 

--- a/beam-sdks-java-io-solace/src/test/java/com/solace/connector/beam/UnboundedSolaceReaderIT.java
+++ b/beam-sdks-java-io-solace/src/test/java/com/solace/connector/beam/UnboundedSolaceReaderIT.java
@@ -11,20 +11,28 @@ import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.XMLMessage;
 import com.solacesystems.jcsmp.XMLMessageProducer;
+import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(BeamPubSubPlusExtension.class)
 public class UnboundedSolaceReaderIT {
 	private UnboundedSolaceReader<SolaceTestRecord> reader;
+	private static final int NUM_TEST_MESSAGES = 10;
 
 	@BeforeEach
 	void setUp(JCSMPSession jcsmpSession, JCSMPProperties jcsmpProperties, Queue queue) throws Exception {
@@ -38,7 +46,7 @@ public class UnboundedSolaceReaderIT {
 
 		XMLMessageProducer producer = jcsmpSession.getMessageProducer(new PublisherEventHandler());
 		try {
-			IntStream.range(0, 10)
+			IntStream.range(0, NUM_TEST_MESSAGES)
 					.mapToObj(i -> JCSMPFactory.onlyInstance().createMessage(BytesMessage.class))
 					.peek(m -> m.setData(RandomUtils.nextBytes(100)))
 					.forEach((ThrowingConsumer<XMLMessage>) m -> producer.send(m, queue));
@@ -70,5 +78,46 @@ public class UnboundedSolaceReaderIT {
 		reader.setUp();
 		String clientName2 = reader.getClientName();
 		assertEquals(clientName1, clientName2);
+	}
+
+	@Test
+	public void testConsecutiveGetCurrent() throws Exception {
+		assertTrue(reader.start());
+		assertSame(reader.getCurrent(), reader.getCurrent());
+	}
+
+	@Test
+	public void testAdvanceFlowRebind() throws Exception {
+		assertTrue(reader.start());
+		List<SolaceTestRecord> receivedMessages = new ArrayList<>();
+		receivedMessages.add(reader.getCurrent());
+		for (int i = 1; i < NUM_TEST_MESSAGES; i++) {
+			assertTrue(reader.advance());
+			receivedMessages.add(reader.getCurrent());
+		}
+
+		reader.flowReceiver.close();
+		assertFalse(reader.advance());
+		assertSame(receivedMessages.get(receivedMessages.size() - 1), reader.getCurrent(),
+				"Even though the ack queue was cleared, " +
+				"the last read message must still be able to be received by the framework when requested for it. " +
+				"At worst, this can cause the latest message to be processed twice due to redelivery.");
+
+		for (SolaceTestRecord message : receivedMessages) {
+			assertTrue(reader.advance());
+			SolaceTestRecord redeliveredMessage = reader.getCurrent();
+			assertNotSame(message, redeliveredMessage);
+			assertTrue(redeliveredMessage.isRedelivered());
+			assertEquals(message.getPayload(), redeliveredMessage.getPayload());
+		}
+
+		UnboundedSource.CheckpointMark checkpointMark = reader.getCheckpointMark();
+		checkpointMark.finalizeCheckpoint();
+
+		assertEquals(1, reader.readerStats.getPollFlowRebind());
+		assertEquals(receivedMessages.size(), reader.readerStats.getMessagesRemovedFromCheckpointQueue());
+		assertEquals(receivedMessages.size(), reader.readerStats.getCheckpointReadyMessages());
+		assertEquals(receivedMessages.size(), reader.readerStats.getCheckpointCompleteMessages());
+		assertEquals(receivedMessages.size() * 2L, reader.readerStats.getMsgRecieved());
 	}
 }


### PR DESCRIPTION
Fix checkpoint finalization throwing `"Attempted an operation on a closed message consumer."` after a flow rebind.