### PR TITLE
Add backwards compatibility jobs for SDK 2.20.0 and 2.25.0

### DIFF
--- a/.github/workflows/test-dataflow.yml
+++ b/.github/workflows/test-dataflow.yml
@@ -26,6 +26,7 @@ jobs:
 
     strategy:
       matrix:
+        beam-version: [ "", "2.20.0", "2.25.0" ]
         experiments: [ "", "use_sdf_read", "use_deprecated_read" ]
 
     steps:
@@ -36,9 +37,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-test-dataflow-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-test-dataflow-${{ matrix.beam-version }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-test-dataflow-
+            ${{ runner.os }}-maven-test-dataflow-${{ matrix.beam-version }}-
       - name: Setup JDK 8
         uses: actions/setup-java@v2
         with:
@@ -54,7 +55,10 @@ jobs:
         run: mvn clean install -f solace-integration-test-support/ -DskipTests
       - name: Build and Run Tests
         run: >-
-          mvn clean verify "-DbeamTestPipelineOptions=[
+          mvn clean verify
+          ${{ matrix.beam-version && format('-Dbeam.version={0}', matrix.beam-version) || '' }}
+          ${{ (matrix.beam-version || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/master' )) && '-Dit.test=SolaceIOIT#testBasic,SolaceRecordTestIT#testBasic' || '' }}
+          "-DbeamTestPipelineOptions=[
           \"--runner=TestDataflowRunner\",
           \"--experiments=${{ matrix.experiments }}\",
           \"--tempRoot=${{ secrets.GCP_DATAFLOW_TEMP_ROOT }}\",

--- a/.github/workflows/test-dataflow.yml
+++ b/.github/workflows/test-dataflow.yml
@@ -53,11 +53,31 @@ jobs:
           export_default_credentials: true
       - name: Install Test Support
         run: mvn clean install -f solace-integration-test-support/ -DskipTests
+      - name: Select Test Suite
+        id: test-suite-selector
+        run: |
+          if [[ -n "${{ matrix.beam-version }}" ]]; then
+            if [[ "${{ github.event_name }}" != 'push' ]] || [[ "${{ github.ref }}" =~ ^refs\/(heads\/master|tags\/.+)$ ]]; then
+              echo 'Will run expanded minimal test suite'
+              echo "::set-output name=it-tests::${EMIN_TEST_SUITE}"
+            else
+              echo 'Will run minimal test suite'
+              echo "::set-output name=it-tests::${MIN_TEST_SUITE}"
+            fi
+          elif [[ "${{ github.event_name }}" == 'push' ]] && [[ "${{ github.ref }}" == refs/heads/* ]] && [[ "${{ github.ref }}" != 'refs/heads/master' ]]; then
+            echo 'Will run minimal test suite'
+            echo "::set-output name=it-tests::${MIN_TEST_SUITE}"
+          else
+            echo 'Will run full test suite'
+          fi
+        env:
+          MIN_TEST_SUITE: SolaceIOIT#testBasic,SolaceRecordTestIT#testBasic
+          EMIN_TEST_SUITE: SolaceIOIT#testBasic,SolaceRecordTestIT#testBasic,*DataflowIT
       - name: Build and Run Tests
         run: >-
           mvn clean verify
           ${{ matrix.beam-version && format('-Dbeam.version={0}', matrix.beam-version) || '' }}
-          ${{ (matrix.beam-version || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/master' )) && '-Dit.test=SolaceIOIT#testBasic,SolaceRecordTestIT#testBasic' || '' }}
+          ${{ steps.test-suite-selector.outputs.it-tests && format('-Dit.test={0}', steps.test-suite-selector.outputs.it-tests) || '' }}
           "-DbeamTestPipelineOptions=[
           \"--runner=TestDataflowRunner\",
           \"--experiments=${{ matrix.experiments }}\",

--- a/.github/workflows/test-direct.yml
+++ b/.github/workflows/test-direct.yml
@@ -27,7 +27,8 @@ jobs:
 
     strategy:
       matrix:
-        experiments: ["", "use_sdf_read", "use_deprecated_read"]
+        beam-version: [ "", "2.20.0", "2.25.0" ]
+        experiments: [ "", "use_sdf_read", "use_deprecated_read" ]
 
     steps:
       - uses: actions/checkout@v2
@@ -37,9 +38,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-test-direct-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-test-direct-${{ matrix.beam-version }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-test-direct-
+            ${{ runner.os }}-maven-test-direct-${{ matrix.beam-version }}-
       - name: Setup JDK 8
         uses: actions/setup-java@v2
         with:
@@ -48,4 +49,7 @@ jobs:
       - name: Install Test Support
         run: mvn clean install -f solace-integration-test-support/ -DskipTests
       - name: Build and Run Tests
-        run: mvn clean verify "-DbeamTestPipelineOptions=[\"--experiments=${{ matrix.experiments }}\"]"
+        run: >-
+          mvn clean verify
+          ${{ matrix.beam-version && format('-Dbeam.version={0}', matrix.beam-version) || '' }}
+          "-DbeamTestPipelineOptions=[\"--experiments=${{ matrix.experiments }}\"]"

--- a/beam-sdks-java-io-solace/pom.xml
+++ b/beam-sdks-java-io-solace/pom.xml
@@ -178,6 +178,16 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+			</plugin>
+
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
 				<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,41 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M5</version>
+          <configuration>
+            <rerunFailingTestsCount>5</rerunFailingTestsCount>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>3.0.0-M5</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <rerunFailingTestsCount>5</rerunFailingTestsCount>
+            <!--
+			  Surefire's Manifest-Only Jar isn't properly interpreted by Apache Beam when detecting "filesToStage".
+			  More info here: http://maven.apache.org/surefire/maven-failsafe-plugin/examples/class-loading.html
+			-->
+            <useManifestOnlyJar>false</useManifestOnlyJar>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -170,37 +205,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
-        <configuration>
-          <rerunFailingTestsCount>5</rerunFailingTestsCount>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M5</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <rerunFailingTestsCount>5</rerunFailingTestsCount>
-          <!--
-			Surefire's Manifest-Only Jar isn't properly interpreted by Apache Beam when detecting "filesToStage".
-			More info here: http://maven.apache.org/surefire/maven-failsafe-plugin/examples/class-loading.html
-		  -->
-          <useManifestOnlyJar>false</useManifestOnlyJar>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/solace-apache-beam-samples/pom.xml
+++ b/solace-apache-beam-samples/pom.xml
@@ -175,6 +175,16 @@
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+			</plugin>
+
 			<!-- Ensure that the Maven jar plugin runs before the Maven
 					shade plugin by listing the plugin higher within the file. -->
 			<plugin>


### PR DESCRIPTION
Update Github action workflows to run a full direct test suite and a basic Dataflow test suite for Beam SDKs 2.20.0 and 2.25.0.