### PR TITLE
exclude confluent dependencies from dataflow-runner test dependency

### DIFF
--- a/beam-sdks-java-io-solace/pom.xml
+++ b/beam-sdks-java-io-solace/pom.xml
@@ -163,6 +163,16 @@
 			<groupId>org.apache.beam</groupId>
 			<artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>io.confluent</groupId>
+					<artifactId>kafka-avro-serializer</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.confluent</groupId>
+					<artifactId>kafka-schema-registry-client</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/solace-apache-beam-samples/pom.xml
+++ b/solace-apache-beam-samples/pom.xml
@@ -91,6 +91,16 @@
 			<groupId>org.apache.beam</groupId>
 			<artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>io.confluent</groupId>
+					<artifactId>kafka-avro-serializer</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.confluent</groupId>
+					<artifactId>kafka-schema-registry-client</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Exclude confluent dependencies from `beam-runners-google-cloud-dataflow-java` test dependency so that build systems don't need to access to the https://packages.confluent.io repository.