### PR TITLE
1.2.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Here is how to include the Beam I/O Connector in your project using Gradle and M
 #### Using it with Gradle
 ```groovy
 // Solace PubSub+ Connector for Beam: I/O
-compile("com.solace.connector.beam:beam-sdks-java-io-solace:1.1.0")
+compile("com.solace.connector.beam:beam-sdks-java-io-solace:1.2.0")
 ```
 
 #### Using it with Maven
@@ -87,7 +87,7 @@ compile("com.solace.connector.beam:beam-sdks-java-io-solace:1.1.0")
 <dependency>
   <groupId>com.solace.connector.beam</groupId>
   <artifactId>beam-sdks-java-io-solace</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
 </dependency>
 ```
 

--- a/beam-sdks-java-io-solace/pom.xml
+++ b/beam-sdks-java-io-solace/pom.xml
@@ -97,6 +97,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>

--- a/beam-sdks-java-io-solace/pom.xml
+++ b/beam-sdks-java-io-solace/pom.xml
@@ -56,14 +56,14 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-codec</artifactId>
-			<version>4.1.49.Final</version>
+			<version>4.1.72.Final</version>
 		</dependency>
 
 		<!-- Fixes netty-codec-http:4.1.30.Final -->
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-codec-http</artifactId>
-			<version>4.1.59.Final</version>
+			<version>4.1.72.Final</version>
 		</dependency>
 
 		<!-- Fixes okhttp:2.5.0 -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <repoName>SolaceProducts</repoName>
 
-    <beam.version>2.31.0</beam.version>
+    <beam.version>2.35.0</beam.version>
     <jcsmp.version>10.12.0</jcsmp.version>
     <slf4j.version>1.7.25</slf4j.version>
     <pmd.version>6.37.0</pmd.version>

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
       <distributionManagement>
         <snapshotRepository>
           <id>ossrh</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
       </distributionManagement>
       <build>
@@ -430,7 +430,7 @@
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
               <!--<stagingProfileId>1d86d96a0b6bce</stagingProfileId> -->
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <repoName>SolaceProducts</repoName>
 
     <beam.version>2.35.0</beam.version>
-    <jcsmp.version>10.12.0</jcsmp.version>
+    <jcsmp.version>10.13.0</jcsmp.version>
     <slf4j.version>1.7.25</slf4j.version>
     <pmd.version>6.37.0</pmd.version>
 

--- a/solace-apache-beam-samples/pom.xml
+++ b/solace-apache-beam-samples/pom.xml
@@ -32,7 +32,6 @@
 	<properties>
 		<beam.version>2.35.0</beam.version>
 		<solace-beam.version>1.2.0-SNAPSHOT</solace-beam.version>
-		<log4j.version>2.14.1</log4j.version>
 
 		<maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
 		<maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
@@ -41,6 +40,14 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>2.17.1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>org.apache.beam</groupId>
 				<artifactId>beam-sdks-java-bom</artifactId>
@@ -66,7 +73,6 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j.version}</version>
 		</dependency>
 
 		<dependency>

--- a/solace-apache-beam-samples/pom.xml
+++ b/solace-apache-beam-samples/pom.xml
@@ -30,7 +30,7 @@
 	<description>Samples for the Apache Beam I/O Component for Solace PubSub+</description>
 
 	<properties>
-		<beam.version>2.31.0</beam.version>
+		<beam.version>2.35.0</beam.version>
 		<solace-beam.version>1.2.0-SNAPSHOT</solace-beam.version>
 		<log4j.version>2.14.1</log4j.version>
 
@@ -118,6 +118,13 @@
 		<dependency>
 			<groupId>com.solace.test.integration</groupId>
 			<artifactId>solace-semp-v2-client</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
* Upgrade beam SDK to `2.35.0`
* Upgrade JCSMP to `10.13.0`
* Upgrade netty-codec to `4.1.72.Final`
* Upgrade netty-codec-http to `4.1.72.Final`
* Upgrade log4j to `2.17.1`
* Change sonatype url to `https://s01.oss.sonatype.org`